### PR TITLE
[Usability Enhancements] Remove dependence on Python, Auto-detect Git URL

### DIFF
--- a/app/components/PageRadialMap/PageRadialMap.container.js
+++ b/app/components/PageRadialMap/PageRadialMap.container.js
@@ -1,9 +1,8 @@
 import { connect } from 'react-redux';
 
 // Redux machinery
-import { setFilePath } from '../../store/actions/file-tree';
 import { filePath$, folderStructure$ } from '../../store/selectors/file-tree';
-import { getFolderStructurePython } from '../../store/actions/file-tree';
+import { setFilePath , getFolderStructure } from '../../store/actions/file-tree';
 
 import PageRadialMap from './PageRadialMap';
 
@@ -12,7 +11,7 @@ const mapStateToProps = state => ({
   folderStructure: folderStructure$(state)
 });
 const mapDispatchToProps = {
-  getFolderStructurePython,
+  getFolderStructure,
   setFilePath
 };
 

--- a/app/components/PageRadialMap/PageRadialMap.jsx
+++ b/app/components/PageRadialMap/PageRadialMap.jsx
@@ -18,7 +18,7 @@ const PageRadialMap = (props) => {
     filePath,
     folderStructure,
     setFilePath,
-    getFolderStructurePython
+    getFolderStructure
   } = props; // use same redux state as the sibling page, decouple this in the future.
   const handleOpenFileOrDirectory = useCallback(
     () => {
@@ -35,9 +35,9 @@ const PageRadialMap = (props) => {
 
   const handleFetchTree = useCallback(
     () => {
-      getFolderStructurePython(filePath);
+      getFolderStructure(filePath);
     },
-    [filePath, getFolderStructurePython]
+    [filePath, getFolderStructure]
   );
 
   const appBarProps = {

--- a/app/components/PageRadialMap/PageRadialMap.jsx
+++ b/app/components/PageRadialMap/PageRadialMap.jsx
@@ -1,44 +1,31 @@
-import React, { useCallback } from "react";
+import React, { useCallback } from 'react';
 
 import { remote } from 'electron';
+import useDimensions from 'react-use-dimensions';
 
 import { Navbar } from '../Navbar';
 import RepositoryRadialMap from './RadialMap';
 
-import useDimensions from "react-use-dimensions";
-
-
-import DEFAULT_FOLDER_DATA from "./facebook-react.json";
+import DEFAULT_FOLDER_DATA from './facebook-react.json';
 
 const { dialog } = remote; // Open file dialog
 
 // Memoize if this gets slow
-const PageRadialMap = (props) => {
-  const {
-    filePath,
-    folderStructure,
-    setFilePath,
-    getFolderStructure
-  } = props; // use same redux state as the sibling page, decouple this in the future.
-  const handleOpenFileOrDirectory = useCallback(
-    () => {
-      dialog.showOpenDialog({ properties: ['openDirectory'] }).then(payload => {
-        const { canceled, filePaths } = payload;
-        if (canceled) {
-          return;
-        }
-        setFilePath(filePaths[0]); // for now, single-select.
-      });
-    },
-    [setFilePath]
-  );
+const PageRadialMap = props => {
+  const { filePath, folderStructure, setFilePath, getFolderStructure } = props; // use same redux state as the sibling page, decouple this in the future.
+  const handleOpenFileOrDirectory = useCallback(() => {
+    dialog.showOpenDialog({ properties: ['openDirectory'] }).then(payload => {
+      const { canceled, filePaths } = payload;
+      if (canceled) {
+        return;
+      }
+      setFilePath(filePaths[0]); // for now, single-select.
+    });
+  }, [setFilePath]);
 
-  const handleFetchTree = useCallback(
-    () => {
-      getFolderStructure(filePath);
-    },
-    [filePath, getFolderStructure]
-  );
+  const handleFetchTree = useCallback(() => {
+    getFolderStructure(filePath);
+  }, [filePath, getFolderStructure]);
 
   const appBarProps = {
     handleOpenFileClick: handleOpenFileOrDirectory,
@@ -53,10 +40,10 @@ const PageRadialMap = (props) => {
 
   return (
     <div ref={ref}>
-      <Navbar {...appBarProps}></Navbar>
-      {width && <RepositoryRadialMap folderData={folderData} width={width}></RepositoryRadialMap>}
+      <Navbar {...appBarProps}/>}
+      {width && <RepositoryRadialMap folderData={folderData} width={width} />}
     </div>
-  )
+  );
 };
 
 export default PageRadialMap;

--- a/app/ipc-server/server-handlers.js
+++ b/app/ipc-server/server-handlers.js
@@ -1,5 +1,4 @@
 // Run other scripts
-const { exec } = require('child_process');
 const util = require('util');
 
 // Filepaths
@@ -16,16 +15,15 @@ const gitlog = require('gitlog');
 const rg = require('ripgrep-js');
 const directoryTree = require('directory-tree');
 
-
 // Based on https://github.com/jlongster/electron-with-server-example/blob/master/server-handlers.js
-const handlers = {}
+const handlers = {};
 
-handlers['get-file-dependency-tree'] = async (payload) => {
+handlers['get-file-dependency-tree'] = async payload => {
   console.log('Generating Madge Dependency Tree');
 
   // get relative path to current location
   const { absPath, webpackConfig } = payload;
-  const relativePath = path.relative(process.env.PWD, absPath)
+  const relativePath = path.relative(process.env.PWD, absPath);
 
   const config = {
     fileExtensions: ['js', 'jsx', 'ts', 'tsx']
@@ -35,20 +33,19 @@ handlers['get-file-dependency-tree'] = async (payload) => {
   }
 
   const result = await madge(relativePath, config)
-    .then(res =>
-      // console.log(res)
-       res
+    .then(
+      res =>
+        // console.log(res)
+        res
     )
     .then(res => res.dot())
     .catch(error => {
       console.log(error);
-    })
-    ;
-
+    });
   return result;
-}
+};
 
-handlers['get-directory-tree'] = async (payload) => {
+handlers['get-directory-tree'] = async payload => {
   console.log('Getting directory structure');
 
   // get relative path to current location
@@ -70,7 +67,7 @@ handlers['get-ripgrep-results'] = async payload => {
   if (searchText) {
     options.string = searchText;
   } else {
-    options.regex = searchRegex
+    options.regex = searchRegex;
   }
 
   // In future: support ripgrep RUST flavored regex
@@ -79,61 +76,52 @@ handlers['get-ripgrep-results'] = async payload => {
   return results;
 };
 
-
-handlers['get-git-logs'] = async (payload) => {
+handlers['get-git-logs'] = async payload => {
   console.log('getting git log data');
 
   const { absPath } = payload;
   const parentFolder = path.dirname(absPath);
 
-    // Let's find the current git repository for that particular file
-    // Use the promise version instead of the callback: https://www.npmjs.com/package/simple-git
+  // Let's find the current git repository for that particular file
+  // Use the promise version instead of the callback: https://www.npmjs.com/package/simple-git
   const gitDirectory = await git(parentFolder).revparse(['--show-toplevel']);
 
   // Then, we'll get the git history for that file!
   // https://github.com/domharrington/node-gitlog#optional-fields
   const options = {
     repo: gitDirectory,
-    fields: [
-      'authorName',
-      'committerDate',
-      'subject',
-      'abbrevHash'
-    ],
+    fields: ['authorName', 'committerDate', 'subject', 'abbrevHash'],
     file: absPath,
     number: 20
-  }
+  };
 
-  let commits = gitlog(options);
-  return commits;
+  return gitlog(options);
 };
 
 // Call Amelia's python script:
 function execShellCommand(cmd) {
- const exec = require('child_process').exec;
- return new Promise((resolve, reject) => {
-  exec(cmd, (error, stdout, stderr) => {
-   if (error) {
-    console.warn(error);
-   }
-   resolve(stdout? stdout : stderr);
+  const exec = require('child_process').exec;
+  return new Promise((resolve, reject) => {
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        console.warn(error);
+      }
+      resolve(stdout ? stdout : stderr);
+    });
   });
- });
 }
 
 // Use a shell command to get the required data structure
 async function getFolderStructureShell(absPath) {
   const command = `./app/ipc-server/folder_structure_to_json.py ${absPath}`;
-  console.log("Running command");
+  console.log('Running command');
   console.log(command);
   const hierarchy = await execShellCommand(command).then(response => {
-    console.log(response);
     const parsed = JSON.parse(response);
     return parsed;
   });
   return hierarchy;
 }
-
 
 async function getFolderStructureNode(absPath) {
   // Let's find the current git repository for that particular file
@@ -142,44 +130,51 @@ async function getFolderStructureNode(absPath) {
   const logOptions = {
     repo: gitDirectory,
     fields: ['committerDate'],
-    number: 1000, // arbitrary maximum limit to avoid timing out requests. # of commits to look back.
+    number: 1000 // arbitrary maximum limit to avoid timing out requests. # of commits to look back.
   };
 
+  let itemCount = 0;
   const relativePath = path.relative(process.env.PWD, absPath);
-  const hierarchy = directoryTree(relativePath, { exclude: [
-    /node_modules/,
-    /\.git/
-  ]}, (item, PATH, status) => {
-    // First, apply folder type
-    if (item.type === 'directory') {
-      item.type === 'folder'; // backwards compat with the python script
-    } else {
-      const { extension } = item;
-      if (extension.startsWith('.')) {
-        item.type = extension.substr(1); // only remove first ., to account for double . extensions like .d.ts
-      } else {
-        item.type = 'text';
-      }
-    }
+  const hierarchy = directoryTree(
+    relativePath,
+    { exclude: [/node_modules/, /\.git/] },
+    (item, PATH, status) => {
+      // 0th: apply an item id
+      item.id = itemCount;
+      itemCount = itemCount + 1;
 
-    // Then, supply git metadata
-    const localPath = path.resolve(item.path);
-    // If file has been .gitignored, it won't have data.
-    const lastEdit = gitlog({ ...logOptions, file: localPath, number: 1 })[0];
-    item.last_edit = lastEdit ? lastEdit.committerDate : '';
-    item.num_of_edits = gitlog({...logOptions, file: localPath}).length;
-  });
+      // First, apply folder type
+      if (item.type === 'directory') {
+        item.type === 'folder'; // backwards compat with the python script
+        // If it's a folder, there won't be any git metadata about it.
+        return;
+      } else {
+        const { extension } = item;
+        if (extension.startsWith('.')) {
+          item.type = extension.substr(1); // only remove first ., to account for double . extensions like .d.ts
+        } else {
+          item.type = 'text';
+        }
+      }
+
+      // Then, supply git metadata
+      const localPath = path.resolve(item.path);
+      // If file has been .gitignored, it won't have data.
+      const lastEdit = gitlog({ ...logOptions, file: localPath, number: 1 })[0];
+      item.last_edit = lastEdit ? lastEdit.committerDate : '';
+      item.num_of_edits = gitlog({ ...logOptions, file: localPath }).length;
+
+      // Lastly, let's pull the absolute path off to shrink the payload
+      item.path = item.path.split(relativePath)[1];
+    }
+  );
   return hierarchy;
 }
 
-async function getRemoteUrl(absPath) {
-  const isVerbose = true; // include URLs and purpose
-  const remotes = await git(absPath).getRemotes(isVerbose);
-  return remotes;
-}
-
 handlers['get-folder-structure'] = async payload => {
-  console.log('Getting directory structure from python script, along with OS metadata');
+  console.log(
+    'Getting directory structure, OS, and git metadata from the filesystem'
+  );
   const { absPath } = payload;
   const useShell = false; // toggle if the node script is broken.
   if (useShell) {
@@ -190,4 +185,45 @@ handlers['get-folder-structure'] = async payload => {
   }
 };
 
-module.exports = handlers
+async function getRemotes(absPath) {
+  const isVerbose = true; // include URLs and purpose
+  return await git(absPath).getRemotes(isVerbose);
+}
+
+const removeSuffix = (text, suffix) => {
+  return text.split(suffix)[0];
+};
+
+handlers['get-remote-url'] = async payload => {
+  console.log(
+    'attempt to guess the URL needed to open remote links for these files'
+  );
+  const { absPath } = payload;
+  const remotes = await getRemotes(absPath);
+  // Find the primary remote
+  const originRemote = remotes.find(remote => remote.name === 'origin');
+  if (originRemote) {
+    const { fetch } = originRemote.refs;
+    // Need to get HTTP url if it doesn't start with HTTPs... handle my case first, adapt to HTTPs too.
+    if (fetch.startsWith('git@github.com:')) {
+      const repositoryWithExtension = fetch.split('git@github.com:')[1];
+      const [
+        organization,
+        projectWithExtension
+      ] = repositoryWithExtension.split('/');
+      const project = removeSuffix(projectWithExtension, '.git');
+      console.log({
+        project,
+        organization
+      });
+      // assume there exists a default branch called master
+      return `https://github.com/${organization}/${project}/blob/master`;
+    } else {
+      return `${removeSuffix(fetch, '.git')}/blob/master`;
+    }
+  }
+
+  return ''; // TODO: maybe in this case, open file on filesystem instead
+};
+
+module.exports = handlers;

--- a/app/store/actions/file-tree.js
+++ b/app/store/actions/file-tree.js
@@ -5,6 +5,7 @@ export const SET_FILE_TREE = 'SET_FILE_TREE'; // actual data
 export const SET_FOLDER_STRUCTURE = 'SET_FOLDER_STRUCTURE'; // actual data
 export const SET_SEARCH_RESULTS = 'SET_SEARCH_RESULTS'; // list of result objects
 export const SET_FILE_PATH = 'SET_FILE_PATH'; // path to imported file
+export const SET_REMOTE_URL = 'SET_REMOTE_URL'; // path to imported file
 
 
 export function setFileTree(fileTree) {
@@ -23,6 +24,9 @@ export function setFilePath(filePath) {
   return { type: SET_FILE_PATH, payload: { filePath } }; // as string
 }
 
+export function setRemoteUrl(remoteUrl) {
+  return { type: SET_REMOTE_URL, payload: { remoteUrl } }; // as string
+}
 
 export function getFileTree(folderPath) {
   return async (dispatch) => {
@@ -41,10 +45,15 @@ export function getSearchResults(searchText, folderPath) {
   };
 }
 
-// Amelia's Script
-// temporarily overload
 export function getFolderStructure(folderPath) {
   return async (dispatch) => {
+    // Temporary: handle both of these actions at the same time so that the links should all work @same time
+    // in future, remoteUrl should go into its own action.
+      const remoteUrl = await send('get-remote-url', {
+        absPath: folderPath
+      });
+      dispatch(setRemoteUrl(remoteUrl));
+
       const folderStructure = await send('get-folder-structure', {
         absPath: folderPath
       });

--- a/app/store/actions/file-tree.js
+++ b/app/store/actions/file-tree.js
@@ -43,9 +43,9 @@ export function getSearchResults(searchText, folderPath) {
 
 // Amelia's Script
 // temporarily overload
-export function getFolderStructurePython(folderPath) {
+export function getFolderStructure(folderPath) {
   return async (dispatch) => {
-      const folderStructure = await send('get-folder-structure-python', {
+      const folderStructure = await send('get-folder-structure', {
         absPath: folderPath
       });
       dispatch(setFolderStructure(folderStructure));

--- a/app/store/reducers/file-tree.js
+++ b/app/store/reducers/file-tree.js
@@ -3,7 +3,8 @@ import {
   SET_FILE_TREE,
   SET_SEARCH_RESULTS,
   SET_FILE_PATH,
-  SET_FOLDER_STRUCTURE
+  SET_FOLDER_STRUCTURE,
+  SET_REMOTE_URL
 } from '../actions/file-tree';
 
 const DEFAULT_PATH = '/Users/cameron/Projects/open-source/d3-quadtree/src';
@@ -13,6 +14,7 @@ const defaultState = {
   filePath: DEFAULT_PATH, // default thing to load
   // Temporary home for python script related state, before a new reducer is made
   folderStructure: undefined,
+  remoteUrl: ''
 };
 
 // Store data relating to the dependency tree
@@ -27,6 +29,8 @@ export default function fileTree(state = defaultState, action) {
       return { ...state, filePath: action.payload.filePath };
     case SET_FOLDER_STRUCTURE:
       return { ...state, folderStructure: action.payload.folderStructure };
+    case SET_REMOTE_URL:
+      return { ...state, remoteUrl: action.payload.remoteUrl };
     default:
       return state;
   }

--- a/app/store/selectors/file-tree.js
+++ b/app/store/selectors/file-tree.js
@@ -19,6 +19,11 @@ export const folderStructure$ = createSelector(
   state => state.folderStructure
 );
 
+export const remoteUrl$ = createSelector(
+  fileTreeState$,
+  state => state.remoteUrl
+);
+
 // DOT format string
 export const fileTree$ = createSelector(
   fileTreeState$,
@@ -116,6 +121,7 @@ export const fileTreeList$ = createSelector(
 export default {
   fileTree$,
   fileTreeList$,
+  remoteUrl$,
   // visNetworkGraph$,
   // networkXGraph$
 };


### PR DESCRIPTION

The first commit removes the dependency on python and `git-python`, without a noticeable performance regression. 

The second commit fixes the "click node to view file" feature for repositories that aren't the initial facebook demo.

More lines were modified than are necessary for this change because I changed my VSCode formatter settings, in the future I'd like to contain that type of change to its own commit.